### PR TITLE
fix(Bridging-Header.h): import OpenTok.h

### DIFF
--- a/BasicVideoChat/ios/BasicVideoChat-Bridging-Header.h
+++ b/BasicVideoChat/ios/BasicVideoChat-Bridging-Header.h
@@ -5,3 +5,4 @@
 #import <React/RCTBridgeMethod.h>
 #import <React/RCTViewManager.h>
 #import <React/RCTEventEmitter.h>
+#import <OpenTok/OpenTok.h>

--- a/Signaling/ios/Signaling-Bridging-Header.h
+++ b/Signaling/ios/Signaling-Bridging-Header.h
@@ -5,3 +5,4 @@
 #import <React/RCTBridgeMethod.h>
 #import <React/RCTViewManager.h>
 #import <React/RCTEventEmitter.h>
+#import <OpenTok/OpenTok.h>


### PR DESCRIPTION
If this file is not included in projects which use newer versions of the lib, you'll have a bunch of `Undeclared Type...` errors preventing the build.