### PR TITLE
Remove enableStereoOutput setting

### DIFF
--- a/Multiparty/App.js
+++ b/Multiparty/App.js
@@ -260,8 +260,7 @@ class App extends Component {
             apiKey={this.apiKey}
             sessionId={this.sessionId}
             token={this.token}
-            eventHandlers={this.sessionEventHandlers}
-            options={{enableStereoOutput: true}}>
+            eventHandlers={this.sessionEventHandlers}>
             <OTPublisher
               properties={this.publisherProperties}
               style={styles.publisherStyle}


### PR DESCRIPTION
The enableStereoOutput option causes the app to use a buggy custom audio driver in Android. And it adds no value to the sample app.